### PR TITLE
fix deprecation warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@
  ![Upload Python Package](https://github.com/chaos-bodensee/lektor-html-pretify/workflows/Upload%20Python%20Package/badge.svg)
  ![Linting Python package](https://github.com/chaos-bodensee/lektor-html-pretify/workflows/Linting%20Python%20package/badge.svg)
 
-[Lektor](https://getlektor.com) plugin to pretify the HTML DOM using [Beautiful Soup](https://de.wikipedia.org/wiki/Beautiful_Soup).
+[Lektor](https://getlektor.com) plugin to pretify the HTML DOM using Beautiful Soup.
 
  How does it actually work?
 ----------------------------
- + It uses [Beautiful Soup](https://en.wikipedia.org/wiki/Beautiful_Soup_(HTML_parser))
+ + It uses [Beautiful Soup](https://en.wikipedia.org/wiki/Beautiful_Soup_(HTML_parser)).
  + It looks for rendered ``.html`` files and pretify themi.
 
  Installation
@@ -22,7 +22,7 @@ lektor plugins add lektor-html-pretify
 Or by hand, adding the plugin to the packages section in your lektorproject file:
 ```ini
 [packages]
-lektor-html-pretify = 1.0.2
+lektor-html-pretify = 1.0.3
 ```
  Usage
 ------

--- a/lektor_html_pretify.py
+++ b/lektor_html_pretify.py
@@ -15,7 +15,7 @@ from lektor.reporter import reporter
 
 class HtmlPretifyPlugin(Plugin):
     name = 'html-pretify'
-    description = u'Lektor Plugin to pretify your HTML Dome'
+    description = u'Lektor Plugin to pretify your HTML DOM using BeautifulSoup'
 
     def is_enabled(self, build_flags):
         return bool(build_flags.get('pretifyhtml'))
@@ -42,7 +42,7 @@ class HtmlPretifyPlugin(Plugin):
             f.write( result.prettify(formatter="html") )
             f.truncate()
 
-    def on_after_build_all(self, builder):
+    def on_after_build_all(self, builder, **extra):
         """
         after-build-all lektor event
         """

--- a/setup.py
+++ b/setup.py
@@ -26,8 +26,8 @@ setup(
     name='lektor-html-pretify',
     packages=find_packages(),
     py_modules=['lektor_html_pretify'],
-    # url='[link to your repository]',
-    version='1.0.2',
+    url='[https://github.com/chaos-bodensee/lektor-html-pretify]',
+    version='1.0.3',
     classifiers=[
         'Framework :: Lektor',
         'Environment :: Plugins',


### PR DESCRIPTION
```
/usr/lib/python3.10/site-packages/lektor/pluginsystem.py:174: DeprecationWarning: The plugin "html-pretify" function "on_after_build_all" does not accept extra_flags. It should be updated to accept `**extra` so that it will not break if new parameters are passed to it by newer versions of Lektor.
  warnings.warn()
```